### PR TITLE
Replace ASM block w/C macro for PSTR (#6577)

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -129,10 +129,9 @@ String::~String() {
 // /*********************************************/
 
 inline void String::init(void) {
-    setSSO(false);
-    setCapacity(0);
+    setSSO(true);
     setLen(0);
-    setBuffer(nullptr);
+    wbuffer()[0] = 0;
 }
 
 void String::invalidate(void) {

--- a/tools/sdk/libc/xtensa-lx106-elf/include/sys/pgmspace.h
+++ b/tools/sdk/libc/xtensa-lx106-elf/include/sys/pgmspace.h
@@ -23,7 +23,6 @@ extern "C" {
   // Ref: https://gcc.gnu.org/onlinedocs/gcc-3.2/gcc/Variable-Attributes.html
   // Place each progmem object into its own named section, avoiding conflicts
   #define PROGMEM __attribute__((section( "\".irom.text." __FILE__ "." __STRINGIZE(__LINE__) "."  __STRINGIZE(__COUNTER__) "\"")))
-  #define PROGMEM_PSTR "\".irom0.pstr." __FILE__ "." __STRINGIZE(__LINE__) "."  __STRINGIZE(__COUNTER__) "\""
 #endif
 #ifndef PGM_P
   #define PGM_P              const char *
@@ -36,11 +35,8 @@ extern "C" {
 // 1.5 bytes/string, but in return memcpy_P and strcpy_P will work 4~8x faster
 #ifndef PSTR
     // Adapted from AVR-specific code at https://forum.arduino.cc/index.php?topic=194603.0
-    #define PSTR(str) (__extension__({ \
-        PGM_P ptr; \
-        asm volatile ( ".pushsection " PROGMEM_PSTR ", \"aSM\", @progbits, 1 \n .align 4 \n 0: .string " __STRINGIZE(str) "\n .popsection \n" ); \
-        asm volatile ( "movi %0, 0b" : "=r" (ptr) ); \
-        ptr; }))
+    // Uses C attribute section instead of ASM block to allow for C language string concatenation ("x" "y" === "xy")
+    #define PSTR(s) (__extension__({static const char __c[] __attribute__((__aligned__(4))) __attribute__((section( "\".irom0.pstr." __FILE__ "." __STRINGIZE(__LINE__) "."  __STRINGIZE(__COUNTER__) "\", \"aSM\", @progbits, 1 #"))) = (s); &__c[0];}))
 #endif
 
 // Flash memory must be read using 32 bit aligned addresses else a processor


### PR DESCRIPTION
* Replace ASM block w/C marco for PSTR

GAS doesn't support the C language idiom of catenating two strings
together with quotes (i.e. "x" "y" === "xy").

Specify the section attribute fully in the section attribute, instead,
to allow this.

* Fix WString optimization

PR #6573 introduced a corner case where a blind String() without any
initialization was in an in invalid state because the buffer and len
would not be updated properly.  Concatenating to the empty string could
cause a failure.

Now, set the default state in ::init() to SSO (which is what happened
before when we were using String(char *s="")) and fix the crash.