### PR TITLE
Remove slave code when not using slave mode

### DIFF
--- a/cores/esp8266/twi.h
+++ b/cores/esp8266/twi.h
@@ -54,6 +54,7 @@ void twi_reply(uint8_t);
 //void twi_stop(void);
 void twi_releaseBus(void);
 
+void twi_enableSlaveMode(void);
 
 #ifdef __cplusplus
 }

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -274,10 +274,12 @@ void TwoWire::onReceive( void (*function)(int) ) {
 
 void TwoWire::onReceive( void (*function)(size_t) ) {
   user_onReceive = function;
+  twi_enableSlaveMode();
 }
 
 void TwoWire::onRequest( void (*function)(void) ){
   user_onRequest = function;
+  twi_enableSlaveMode();
 }
 
 // Preinstantiate Objects //////////////////////////////////////////////////////


### PR DESCRIPTION
Add a new twi_setSlaveMode call which actually attached the interrupts
to the slave pin change code onSdaChenge/onSclChange.  Don't attach
interrupts in the main twi_begin.

Because slave mode is only useful should a onoReceive or onRequest
callback, call twi_setSlaveMode and attach interrupts on the Wire
setters.

This allows GCC to not link in slave code unless slave mode is used,
saving over 1,000 bytes of IRAM in the common, master-only case.