### PR TITLE
Reduce the IRAM usage of I2C code by 600-1500 bytes (#6326)

### DIFF
--- a/cores/esp8266/core_esp8266_si2c.cpp
+++ b/cores/esp8266/core_esp8266_si2c.cpp
@@ -1,114 +1,152 @@
 /*
-  si2c.c - Software I2C library for esp8266
+    si2c.c - Software I2C library for esp8266
 
-  Copyright (c) 2015 Hristo Gochkov. All rights reserved.
-  This file is part of the esp8266 core for Arduino environment.
+    Copyright (c) 2015 Hristo Gochkov. All rights reserved.
+    This file is part of the esp8266 core for Arduino environment.
 
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation; either
-  version 2.1 of the License, or (at your option) any later version.
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
 
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
 
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-  Modified January 2017 by Bjorn Hammarberg (bjoham@esp8266.com) - i2c slave support
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+    Modified January 2017 by Bjorn Hammarberg (bjoham@esp8266.com) - i2c slave support
 */
 #include "twi.h"
 #include "pins_arduino.h"
 #include "wiring_private.h"
 
+
+
 extern "C" {
-
-unsigned int preferred_si2c_clock = 100000;
 #include "twi_util.h"
-
 #include "ets_sys.h"
+};
 
-unsigned char twi_dcount = 18;
-static unsigned char twi_sda, twi_scl;
-static uint32_t twi_clockStretchLimit;
-static unsigned char twi_addr = 0;
 
-// modes (private)
-#define TWIPM_UNKNOWN 	0
-#define TWIPM_IDLE 		1
-#define TWIPM_ADDRESSED	2
-#define TWIPM_WAIT		3
+// Implement as a class to reduce code size by allowing access to many global variables with a single base pointer
+class Twi
+{
+private:
+    unsigned int preferred_si2c_clock = 100000;
+    unsigned char twi_dcount = 18;
+    unsigned char twi_sda = 0;
+    unsigned char twi_scl = 0;
+    unsigned char twi_addr = 0;
+    uint32_t twi_clockStretchLimit = 0;
 
-// states (private)
-#define TWIP_UNKNOWN 	0
-#define TWIP_IDLE 		1
-#define TWIP_START 		2
-#define TWIP_SEND_ACK	3
-#define TWIP_WAIT_ACK	4
-#define TWIP_WAIT_STOP	5
-#define TWIP_SLA_W		6
-#define TWIP_SLA_R		7
-#define TWIP_REP_START	8
-#define TWIP_READ		9
-#define TWIP_STOP 		10
-#define TWIP_REC_ACK	11
-#define TWIP_READ_ACK	12
-#define TWIP_RWAIT_ACK	13
-#define TWIP_WRITE		14
-#define TWIP_BUS_ERR 	15
+    // These are int-wide, even though they could all fit in a byte, to reduce code size and avoid any potential
+    // issues about RmW on packed bytes.  The int-wide variations of asm instructions are smaller than the equivalent
+    // byte-wide ones, and since these emums are used everywhere, the difference adds up fast.  There is only a single
+    // instance of the class, though, so the extra 12 bytes of RAM used here saves a lot more IRAM.
+    volatile enum { TWIPM_UNKNOWN = 0, TWIPM_IDLE, TWIPM_ADDRESSED, TWIPM_WAIT} twip_mode = TWIPM_IDLE;
+    volatile enum { TWIP_UNKNOWN = 0, TWIP_IDLE, TWIP_START, TWIP_SEND_ACK, TWIP_WAIT_ACK, TWIP_WAIT_STOP, TWIP_SLA_W, TWIP_SLA_R, TWIP_REP_START, TWIP_READ, TWIP_STOP, TWIP_REC_ACK, TWIP_READ_ACK, TWIP_RWAIT_ACK, TWIP_WRITE, TWIP_BUS_ERR } twip_state = TWIP_IDLE;
+    volatile int twip_status = TW_NO_INFO;
+    volatile int bitCount = 0;
 
-static volatile uint8_t twip_mode = TWIPM_IDLE;
-static volatile uint8_t twip_state = TWIP_IDLE;
-static volatile uint8_t twip_status = TW_NO_INFO;
-static volatile uint8_t bitCount = 0;
+    volatile uint8_t twi_data = 0x00;
+    volatile int twi_ack = 0;
+    volatile int twi_ack_rec = 0;
+    volatile int twi_timeout_ms = 10;
 
-#define TWDR twi_data
-static volatile uint8_t twi_data = 0x00;
-static volatile uint8_t twi_ack = 0;
-static volatile uint8_t twi_ack_rec = 0;
-static volatile int twi_timeout_ms = 10;
+    volatile enum { TWI_READY = 0, TWI_MRX, TWI_MTX, TWI_SRX, TWI_STX } twi_state = TWI_READY;
+    volatile uint8_t twi_error = 0xFF;
 
-#define TWI_READY 0
-#define TWI_MRX   1
-#define TWI_MTX   2
-#define TWI_SRX   3
-#define TWI_STX   4
-static volatile uint8_t twi_state = TWI_READY;
-static volatile uint8_t twi_error = 0xFF;
+    uint8_t twi_txBuffer[TWI_BUFFER_LENGTH];
+    volatile int twi_txBufferIndex = 0;
+    volatile int twi_txBufferLength = 0;
 
-static uint8_t twi_txBuffer[TWI_BUFFER_LENGTH];
-static volatile uint8_t twi_txBufferIndex;
-static volatile uint8_t twi_txBufferLength;
+    uint8_t twi_rxBuffer[TWI_BUFFER_LENGTH];
+    volatile int twi_rxBufferIndex = 0;
 
-static uint8_t twi_rxBuffer[TWI_BUFFER_LENGTH];
-static volatile uint8_t twi_rxBufferIndex;
+    void (*twi_onSlaveTransmit)(void);
+    void (*twi_onSlaveReceive)(uint8_t*, size_t);
 
-static void (*twi_onSlaveTransmit)(void);
-static void (*twi_onSlaveReceive)(uint8_t*, size_t);
+    // ETS queue/timer interfaces
+    enum { EVENTTASK_QUEUE_SIZE = 1, EVENTTASK_QUEUE_PRIO = 2 };
+    enum { TWI_SIG_RANGE = 0x00000100, TWI_SIG_RX = 0x00000101, TWI_SIG_TX = 0x00000102 };
+    ETSEvent eventTaskQueue[EVENTTASK_QUEUE_SIZE];
+    ETSTimer timer;
 
-static void onSclChange(void);
-static void onSdaChange(void);
+    // Event/IRQ callbacks, so they can't use "this" and need to be static
+    static void ICACHE_RAM_ATTR onSclChange(void);
+    static void ICACHE_RAM_ATTR onSdaChange(void);
+    static void eventTask(ETSEvent *e);
+    static void ICACHE_RAM_ATTR onTimer(void *unused);
 
-#define EVENTTASK_QUEUE_SIZE 1
-#define EVENTTASK_QUEUE_PRIO 2
+    // Allow not linking in the slave code if there is no call to setAddress
+    bool _slaveEnabled = false;
 
-#define TWI_SIG_RANGE	0x00000100
-#define TWI_SIG_RX 		(TWI_SIG_RANGE + 0x01)
-#define TWI_SIG_TX 		(TWI_SIG_RANGE + 0x02)
+    // Internal use functions
+    void ICACHE_RAM_ATTR busywait(unsigned char v);
+    bool write_start(void);
+    bool write_stop(void);
+    bool write_bit(bool bit);
+    bool read_bit(void);
+    bool write_byte(unsigned char byte);
+    unsigned char read_byte(bool nack);
+    void ICACHE_RAM_ATTR onTwipEvent(uint8_t status);
 
-static ETSEvent eventTaskQueue[EVENTTASK_QUEUE_SIZE];
-static void eventTask(ETSEvent *e);
-static ETSTimer timer;
-static void onTimer(void *unused);
+    // Inline helpers
+    inline void SDA_LOW()
+    {
+        GPES = (1 << twi_sda);
+    }
+    inline void SDA_HIGH()
+    {
+        GPEC = (1 << twi_sda);
+    }
+    inline bool SDA_READ()
+    {
+        return (GPI & (1 << twi_sda)) != 0;
+    }
+    inline void SCL_LOW()
+    {
+        GPES = (1 << twi_scl);
+    }
+    inline void SCL_HIGH()
+    {
+        GPEC = (1 << twi_scl);
+    }
+    inline bool SCL_READ()
+    {
+        return (GPI & (1 << twi_scl)) != 0;
+    }
+    // Handle the case where a slave needs to stretch the clock with a time-limited busy wait
+    inline void WAIT_CLOCK_STRETCH()
+    {
+        for (unsigned int t = 0; !SCL_READ() && (t < twi_clockStretchLimit); t++)
+        {
+            /* noop */
+        }
+    }
 
-#define SDA_LOW()   (GPES = (1 << twi_sda)) //Enable SDA (becomes output and since GPO is 0 for the pin, it will pull the line low)
-#define SDA_HIGH()  (GPEC = (1 << twi_sda)) //Disable SDA (becomes input and since it has pullup it will go high)
-#define SDA_READ()  ((GPI & (1 << twi_sda)) != 0)
-#define SCL_LOW()   (GPES = (1 << twi_scl))
-#define SCL_HIGH()  (GPEC = (1 << twi_scl))
-#define SCL_READ()  ((GPI & (1 << twi_scl)) != 0)
+
+public:
+    void setClock(unsigned int freq);
+    void setClockStretchLimit(uint32_t limit);
+    void init(unsigned char sda, unsigned char scl);
+    void setAddress(uint8_t address);
+    unsigned char writeTo(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop);
+    unsigned char readFrom(unsigned char address, unsigned char* buf, unsigned int len, unsigned char sendStop);
+    uint8_t status();
+    uint8_t transmit(const uint8_t* data, uint8_t length);
+    void attachSlaveRxEvent(void (*function)(uint8_t*, size_t));
+    void attachSlaveTxEvent(void (*function)(void));
+    inline void ICACHE_RAM_ATTR reply(uint8_t ack);
+    inline void ICACHE_RAM_ATTR stop(void);
+    inline void ICACHE_RAM_ATTR releaseBus(void);
+    void enableSlave();
+};
+
+static Twi twi;
 
 #ifndef FCPU80
 #define FCPU80 80000000L
@@ -120,670 +158,910 @@ static void onTimer(void *unused);
 #define TWI_CLOCK_STRETCH_MULTIPLIER 6
 #endif
 
-void twi_setClock(unsigned int freq){
-  preferred_si2c_clock = freq;
+
+void Twi::setClock(unsigned int freq)
+{
+    preferred_si2c_clock = freq;
 #if F_CPU == FCPU80
-  if(freq <= 50000) twi_dcount = 38;//about 50KHz
-  else if(freq <= 100000) twi_dcount = 19;//about 100KHz
-  else if(freq <= 200000) twi_dcount = 8;//about 200KHz
-  else if(freq <= 300000) twi_dcount = 3;//about 300KHz
-  else if(freq <= 400000) twi_dcount = 1;//about 400KHz
-  else twi_dcount = 1;//about 400KHz
+    if (freq <= 50000)
+    {
+        twi_dcount = 38;  //about 50KHz
+    }
+    else if (freq <= 100000)
+    {
+        twi_dcount = 19;  //about 100KHz
+    }
+    else if (freq <= 200000)
+    {
+        twi_dcount = 8;  //about 200KHz
+    }
+    else if (freq <= 300000)
+    {
+        twi_dcount = 3;  //about 300KHz
+    }
+    else if (freq <= 400000)
+    {
+        twi_dcount = 1;  //about 400KHz
+    }
+    else
+    {
+        twi_dcount = 1;  //about 400KHz
+    }
 #else
-  if(freq <= 50000) twi_dcount = 64;//about 50KHz
-  else if(freq <= 100000) twi_dcount = 32;//about 100KHz
-  else if(freq <= 200000) twi_dcount = 14;//about 200KHz
-  else if(freq <= 300000) twi_dcount = 8;//about 300KHz
-  else if(freq <= 400000) twi_dcount = 5;//about 400KHz
-  else if(freq <= 500000) twi_dcount = 3;//about 500KHz
-  else if(freq <= 600000) twi_dcount = 2;//about 600KHz
-  else twi_dcount = 1;//about 700KHz
+    if (freq <= 50000)
+    {
+        twi_dcount = 64;  //about 50KHz
+    }
+    else if (freq <= 100000)
+    {
+        twi_dcount = 32;  //about 100KHz
+    }
+    else if (freq <= 200000)
+    {
+        twi_dcount = 14;  //about 200KHz
+    }
+    else if (freq <= 300000)
+    {
+        twi_dcount = 8;  //about 300KHz
+    }
+    else if (freq <= 400000)
+    {
+        twi_dcount = 5;  //about 400KHz
+    }
+    else if (freq <= 500000)
+    {
+        twi_dcount = 3;  //about 500KHz
+    }
+    else if (freq <= 600000)
+    {
+        twi_dcount = 2;  //about 600KHz
+    }
+    else
+    {
+        twi_dcount = 1;  //about 700KHz
+    }
 #endif
 }
 
-void twi_setClockStretchLimit(uint32_t limit){
-  twi_clockStretchLimit = limit * TWI_CLOCK_STRETCH_MULTIPLIER;
-}
-
-void twi_init(unsigned char sda, unsigned char scl)
+void Twi::setClockStretchLimit(uint32_t limit)
 {
-  // set timer function
-  ets_timer_setfn(&timer, onTimer, NULL);
-
-  // create event task
-  ets_task(eventTask, EVENTTASK_QUEUE_PRIO, eventTaskQueue, EVENTTASK_QUEUE_SIZE);
-
-  twi_sda = sda;
-  twi_scl = scl;
-  pinMode(twi_sda, INPUT_PULLUP);
-  pinMode(twi_scl, INPUT_PULLUP);
-  twi_setClock(preferred_si2c_clock);
-  twi_setClockStretchLimit(230); // default value is 230 uS
-
-  if (twi_addr != 0)
-  {
-	attachInterrupt(scl, onSclChange, CHANGE);
-	attachInterrupt(sda, onSdaChange, CHANGE);
-  }
+    twi_clockStretchLimit = limit * TWI_CLOCK_STRETCH_MULTIPLIER;
 }
 
-void twi_setAddress(uint8_t address)
+
+
+void Twi::init(unsigned char sda, unsigned char scl)
 {
-  // set twi slave address (skip over R/W bit)
-  twi_addr = address << 1;
+    // set timer function
+    ets_timer_setfn(&timer, onTimer, NULL);
+
+    // create event task
+    ets_task(eventTask, EVENTTASK_QUEUE_PRIO, eventTaskQueue, EVENTTASK_QUEUE_SIZE);
+
+    twi_sda = sda;
+    twi_scl = scl;
+    pinMode(twi_sda, INPUT_PULLUP);
+    pinMode(twi_scl, INPUT_PULLUP);
+    twi_setClock(preferred_si2c_clock);
+    twi_setClockStretchLimit(230); // default value is 230 uS
 }
 
-static void ICACHE_RAM_ATTR twi_delay(unsigned char v){
-  unsigned int i;
+void Twi::setAddress(uint8_t address)
+{
+    // set twi slave address (skip over R/W bit)
+    twi_addr = address << 1;
+}
+
+void Twi::enableSlave()
+{
+    if (!_slaveEnabled)
+    {
+        attachInterrupt(twi_scl, onSclChange, CHANGE);
+        attachInterrupt(twi_sda, onSdaChange, CHANGE);
+        _slaveEnabled = true;
+    }
+}
+
+void ICACHE_RAM_ATTR Twi::busywait(unsigned char v)
+{
+    unsigned int i;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-  unsigned int reg;
-  for (i = 0; i < v; i++) {
-    reg = GPI;
-  }
-  (void)reg;
+    unsigned int reg;
+    for (i = 0; i < v; i++)
+    {
+        reg = GPI;
+    }
+    (void)reg;
 #pragma GCC diagnostic pop
 }
 
-static bool twi_write_start(void) {
-  SCL_HIGH();
-  SDA_HIGH();
-  if (SDA_READ() == 0) {
-    return false;
-  }
-  twi_delay(twi_dcount);
-  SDA_LOW();
-  twi_delay(twi_dcount);
-  return true;
-}
-
-static bool twi_write_stop(void){
-  uint32_t i = 0;
-  SCL_LOW();
-  SDA_LOW();
-  twi_delay(twi_dcount);
-  SCL_HIGH();
-  while (SCL_READ() == 0 && (i++) < twi_clockStretchLimit); // Clock stretching
-  twi_delay(twi_dcount);
-  SDA_HIGH();
-  twi_delay(twi_dcount);
-  return true;
-}
-
-static bool twi_write_bit(bool bit) {
-  uint32_t i = 0;
-  SCL_LOW();
-  if (bit) SDA_HIGH();
-  else SDA_LOW();
-  twi_delay(twi_dcount+1);
-  SCL_HIGH();
-  while (SCL_READ() == 0 && (i++) < twi_clockStretchLimit);// Clock stretching
-  twi_delay(twi_dcount);
-  return true;
-}
-
-static bool twi_read_bit(void) {
-  uint32_t i = 0;
-  SCL_LOW();
-  SDA_HIGH();
-  twi_delay(twi_dcount+2);
-  SCL_HIGH();
-  while (SCL_READ() == 0 && (i++) < twi_clockStretchLimit);// Clock stretching
-  bool bit = SDA_READ();
-  twi_delay(twi_dcount);
-  return bit;
-}
-
-static bool twi_write_byte(unsigned char byte) {
-  unsigned char bit;
-  for (bit = 0; bit < 8; bit++) {
-    twi_write_bit(byte & 0x80);
-    byte <<= 1;
-  }
-  return !twi_read_bit();//NACK/ACK
-}
-
-static unsigned char twi_read_byte(bool nack) {
-  unsigned char byte = 0;
-  unsigned char bit;
-  for (bit = 0; bit < 8; bit++) byte = (byte << 1) | twi_read_bit();
-  twi_write_bit(nack);
-  return byte;
-}
-
-unsigned char twi_writeTo(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop){
-  unsigned int i;
-  if(!twi_write_start()) return 4;//line busy
-  if(!twi_write_byte(((address << 1) | 0) & 0xFF)) {
-    if (sendStop) twi_write_stop();
-    return 2; //received NACK on transmit of address
-  }
-  for(i=0; i<len; i++) {
-    if(!twi_write_byte(buf[i])) {
-      if (sendStop) twi_write_stop();
-      return 3;//received NACK on transmit of data
+bool Twi::write_start(void)
+{
+    SCL_HIGH();
+    SDA_HIGH();
+    if (!SDA_READ())
+    {
+        return false;
     }
-  }
-  if(sendStop) twi_write_stop();
-  i = 0;
-  while(SDA_READ() == 0 && (i++) < 10){
-    SCL_LOW();
-    twi_delay(twi_dcount);
-    SCL_HIGH();
-    unsigned int t=0; while(SCL_READ()==0 && (t++)<twi_clockStretchLimit); // twi_clockStretchLimit
-    twi_delay(twi_dcount);
-  }
-  return 0;
+    busywait(twi_dcount);
+    SDA_LOW();
+    busywait(twi_dcount);
+    return true;
 }
 
-unsigned char twi_readFrom(unsigned char address, unsigned char* buf, unsigned int len, unsigned char sendStop){
-  unsigned int i;
-  if(!twi_write_start()) return 4;//line busy
-  if(!twi_write_byte(((address << 1) | 1) & 0xFF)) {
-    if (sendStop) twi_write_stop();
-    return 2;//received NACK on transmit of address
-  }
-  for(i=0; i<(len-1); i++) buf[i] = twi_read_byte(false);
-  buf[len-1] = twi_read_byte(true);
-  if(sendStop) twi_write_stop();
-  i = 0;
-  while(SDA_READ() == 0 && (i++) < 10){
+bool Twi::write_stop(void)
+{
     SCL_LOW();
-    twi_delay(twi_dcount);
+    SDA_LOW();
+    busywait(twi_dcount);
     SCL_HIGH();
-    unsigned int t=0; while(SCL_READ()==0 && (t++)<twi_clockStretchLimit); // twi_clockStretchLimit
-    twi_delay(twi_dcount);
-  }
-  return 0;
+    WAIT_CLOCK_STRETCH();
+    busywait(twi_dcount);
+    SDA_HIGH();
+    busywait(twi_dcount);
+    return true;
 }
 
-uint8_t twi_status() {
-    if (SCL_READ() == 0)
-      return I2C_SCL_HELD_LOW; // SCL held low by another device, no procedure available to recover
+bool Twi::write_bit(bool bit)
+{
+    SCL_LOW();
+    if (bit)
+    {
+        SDA_HIGH();
+    }
+    else
+    {
+        SDA_LOW();
+    }
+    busywait(twi_dcount + 1);
+    SCL_HIGH();
+    WAIT_CLOCK_STRETCH();
+    busywait(twi_dcount);
+    return true;
+}
 
-    int clockCount = 20;
-    while (SDA_READ() == 0 && clockCount-- > 0) { // if SDA low, read the bits slaves have to sent to a max
-        twi_read_bit();
-        if (SCL_READ() == 0) {
-          return I2C_SCL_HELD_LOW_AFTER_READ; // I2C bus error. SCL held low beyond slave clock stretch time
+bool Twi::read_bit(void)
+{
+    SCL_LOW();
+    SDA_HIGH();
+    busywait(twi_dcount + 2);
+    SCL_HIGH();
+    WAIT_CLOCK_STRETCH();
+    bool bit = SDA_READ();
+    busywait(twi_dcount);
+    return bit;
+}
+
+bool Twi::write_byte(unsigned char byte)
+{
+    unsigned char bit;
+    for (bit = 0; bit < 8; bit++)
+    {
+        write_bit(byte & 0x80);
+        byte <<= 1;
+    }
+    return !read_bit();//NACK/ACK
+}
+
+unsigned char Twi::read_byte(bool nack)
+{
+    unsigned char byte = 0;
+    unsigned char bit;
+    for (bit = 0; bit < 8; bit++)
+    {
+        byte = (byte << 1) | read_bit();
+    }
+    write_bit(nack);
+    return byte;
+}
+
+unsigned char Twi::writeTo(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop)
+{
+    unsigned int i;
+    if (!write_start())
+    {
+        return 4;  //line busy
+    }
+    if (!write_byte(((address << 1) | 0) & 0xFF))
+    {
+        if (sendStop)
+        {
+            write_stop();
+        }
+        return 2; //received NACK on transmit of address
+    }
+    for (i = 0; i < len; i++)
+    {
+        if (!write_byte(buf[i]))
+        {
+            if (sendStop)
+            {
+                write_stop();
+            }
+            return 3;//received NACK on transmit of data
         }
     }
-    if (SDA_READ() == 0)
-      return I2C_SDA_HELD_LOW; // I2C bus error. SDA line held low by slave/another_master after n bits.
-    
-    if (!twi_write_start())
-      return I2C_SDA_HELD_LOW_AFTER_INIT;  // line busy. SDA again held low by another device. 2nd master?
+    if (sendStop)
+    {
+        write_stop();
+    }
+    i = 0;
+    while (!SDA_READ() && (i++) < 10)
+    {
+        SCL_LOW();
+        busywait(twi_dcount);
+        SCL_HIGH();
+        WAIT_CLOCK_STRETCH();
+        busywait(twi_dcount);
+    }
+    return 0;
+}
+
+unsigned char Twi::readFrom(unsigned char address, unsigned char* buf, unsigned int len, unsigned char sendStop)
+{
+    unsigned int i;
+    if (!write_start())
+    {
+        return 4;  //line busy
+    }
+    if (!write_byte(((address << 1) | 1) & 0xFF))
+    {
+        if (sendStop)
+        {
+            write_stop();
+        }
+        return 2;//received NACK on transmit of address
+    }
+    for (i = 0; i < (len - 1); i++)
+    {
+        buf[i] = read_byte(false);
+    }
+    buf[len - 1] = read_byte(true);
+    if (sendStop)
+    {
+        write_stop();
+    }
+    i = 0;
+    while (!SDA_READ() && (i++) < 10)
+    {
+        SCL_LOW();
+        busywait(twi_dcount);
+        SCL_HIGH();
+        WAIT_CLOCK_STRETCH();
+        busywait(twi_dcount);
+    }
+    return 0;
+}
+
+uint8_t Twi::status()
+{
+    if (!SCL_READ())
+    {
+        return I2C_SCL_HELD_LOW;  // SCL held low by another device, no procedure available to recover
+    }
+
+    int clockCount = 20;
+    while (!SDA_READ() && clockCount-- > 0)   // if SDA low, read the bits slaves have to sent to a max
+    {
+        read_bit();
+        if (!SCL_READ())
+        {
+            return I2C_SCL_HELD_LOW_AFTER_READ; // I2C bus error. SCL held low beyond slave clock stretch time
+        }
+    }
+    if (!SDA_READ())
+    {
+        return I2C_SDA_HELD_LOW;  // I2C bus error. SDA line held low by slave/another_master after n bits.
+    }
+
+    if (!write_start())
+    {
+        return I2C_SDA_HELD_LOW_AFTER_INIT;  // line busy. SDA again held low by another device. 2nd master?
+    }
 
     return I2C_OK;
 }
 
-uint8_t twi_transmit(const uint8_t* data, uint8_t length)
+uint8_t Twi::transmit(const uint8_t* data, uint8_t length)
 {
-  uint8_t i;
+    uint8_t i;
 
-  // ensure data will fit into buffer
-  if (length > TWI_BUFFER_LENGTH) {
-    return 1;
-  }
+    // ensure data will fit into buffer
+    if (length > TWI_BUFFER_LENGTH)
+    {
+        return 1;
+    }
 
-  // ensure we are currently a slave transmitter
-  if (twi_state != TWI_STX) {
-    return 2;
-  }
+    // ensure we are currently a slave transmitter
+    if (twi_state != TWI_STX)
+    {
+        return 2;
+    }
 
-  // set length and copy data into tx buffer
-  twi_txBufferLength = length;
-  for (i = 0; i < length; ++i) {
-    twi_txBuffer[i] = data[i];
-  }
+    // set length and copy data into tx buffer
+    twi_txBufferLength = length;
+    for (i = 0; i < length; ++i)
+    {
+        twi_txBuffer[i] = data[i];
+    }
 
-  return 0;
+    return 0;
 }
 
-void twi_attachSlaveRxEvent( void (*function)(uint8_t*, size_t) )
+void Twi::attachSlaveRxEvent(void (*function)(uint8_t*, size_t))
 {
-  twi_onSlaveReceive = function;
+    twi_onSlaveReceive = function;
 }
 
-void twi_attachSlaveTxEvent( void (*function)(void) )
+void Twi::attachSlaveTxEvent(void (*function)(void))
 {
-  twi_onSlaveTransmit = function;
+    twi_onSlaveTransmit = function;
 }
 
-void ICACHE_RAM_ATTR twi_reply(uint8_t ack)
+inline void ICACHE_RAM_ATTR Twi::reply(uint8_t ack)
 {
-  // transmit master read ready signal, with or without ack
-  if (ack) {
-    //TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWINT) | _BV(TWEA);
-	SCL_HIGH();		// _BV(TWINT)
-	twi_ack = 1; 	// _BV(TWEA)
-  } else {
-	//TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWINT);
-	SCL_HIGH();		// _BV(TWINT)
-	twi_ack = 0;	// ~_BV(TWEA)
-  }
+    // transmit master read ready signal, with or without ack
+    if (ack)
+    {
+        //TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWINT) | _BV(TWEA);
+        SCL_HIGH();		// _BV(TWINT)
+        twi_ack = 1; 	// _BV(TWEA)
+    }
+    else
+    {
+        //TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWINT);
+        SCL_HIGH();		// _BV(TWINT)
+        twi_ack = 0;	// ~_BV(TWEA)
+    }
 }
 
-void ICACHE_RAM_ATTR twi_stop(void)
+inline void ICACHE_RAM_ATTR Twi::stop(void)
 {
-	// send stop condition
-	//TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWEA) | _BV(TWINT) | _BV(TWSTO);
-	SCL_HIGH();		// _BV(TWINT)
-	twi_ack = 1;	// _BV(TWEA)
-	twi_delay(5);	// Maybe this should be here
-	SDA_HIGH();		// _BV(TWSTO)
-	// update twi state
-	twi_state = TWI_READY;
+    // send stop condition
+    //TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWEA) | _BV(TWINT) | _BV(TWSTO);
+    SCL_HIGH();		// _BV(TWINT)
+    twi_ack = 1;	// _BV(TWEA)
+    busywait(5);	// Maybe this should be here
+    SDA_HIGH();		// _BV(TWSTO)
+    // update twi state
+    twi_state = TWI_READY;
 }
 
-void ICACHE_RAM_ATTR twi_releaseBus(void)
+inline void ICACHE_RAM_ATTR Twi::releaseBus(void)
 {
-	// release bus
-	//TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWEA) | _BV(TWINT);
-	SCL_HIGH();		// _BV(TWINT)
-	twi_ack = 1; 	// _BV(TWEA)
-	SDA_HIGH();
+    // release bus
+    //TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWEA) | _BV(TWINT);
+    SCL_HIGH();		// _BV(TWINT)
+    twi_ack = 1; 	// _BV(TWEA)
+    SDA_HIGH();
 
-	// update twi state
-	twi_state = TWI_READY;
+    // update twi state
+    twi_state = TWI_READY;
 }
 
 
-void ICACHE_RAM_ATTR twi_onTwipEvent(uint8_t status)
+void ICACHE_RAM_ATTR Twi::onTwipEvent(uint8_t status)
 {
-  switch(status) {
+    twip_status = status;
+    switch (status)
+    {
     // Slave Receiver
     case TW_SR_SLA_ACK:   // addressed, returned ack
     case TW_SR_GCALL_ACK: // addressed generally, returned ack
     case TW_SR_ARB_LOST_SLA_ACK:   // lost arbitration, returned ack
     case TW_SR_ARB_LOST_GCALL_ACK: // lost arbitration, returned ack
-      // enter slave receiver mode
-      twi_state = TWI_SRX;
-      // indicate that rx buffer can be overwritten and ack
-      twi_rxBufferIndex = 0;
-      twi_reply(1);
-      break;
+        // enter slave receiver mode
+        twi_state = TWI_SRX;
+        // indicate that rx buffer can be overwritten and ack
+        twi_rxBufferIndex = 0;
+        reply(1);
+        break;
     case TW_SR_DATA_ACK:       // data received, returned ack
     case TW_SR_GCALL_DATA_ACK: // data received generally, returned ack
-      // if there is still room in the rx buffer
-      if(twi_rxBufferIndex < TWI_BUFFER_LENGTH){
-        // put byte in buffer and ack
-        twi_rxBuffer[twi_rxBufferIndex++] = TWDR;
-        twi_reply(1);
-      }else{
-        // otherwise nack
-        twi_reply(0);
-      }
-      break;
+        // if there is still room in the rx buffer
+        if (twi_rxBufferIndex < TWI_BUFFER_LENGTH)
+        {
+            // put byte in buffer and ack
+            twi_rxBuffer[twi_rxBufferIndex++] = twi_data;
+            reply(1);
+        }
+        else
+        {
+            // otherwise nack
+            reply(0);
+        }
+        break;
     case TW_SR_STOP: // stop or repeated start condition received
-      // put a null char after data if there's room
-      if(twi_rxBufferIndex < TWI_BUFFER_LENGTH){
-        twi_rxBuffer[twi_rxBufferIndex] = '\0';
-      }
-      // callback to user-defined callback over event task to allow for non-RAM-residing code
-	  //twi_rxBufferLock = true; // This may be necessary
-	  ets_post(EVENTTASK_QUEUE_PRIO, TWI_SIG_RX, twi_rxBufferIndex);
+        // put a null char after data if there's room
+        if (twi_rxBufferIndex < TWI_BUFFER_LENGTH)
+        {
+            twi_rxBuffer[twi_rxBufferIndex] = '\0';
+        }
+        // callback to user-defined callback over event task to allow for non-RAM-residing code
+        //twi_rxBufferLock = true; // This may be necessary
+        ets_post(EVENTTASK_QUEUE_PRIO, TWI_SIG_RX, twi_rxBufferIndex);
 
-      // since we submit rx buffer to "wire" library, we can reset it
-      twi_rxBufferIndex = 0;
-      break;
+        // since we submit rx buffer to "wire" library, we can reset it
+        twi_rxBufferIndex = 0;
+        break;
 
     case TW_SR_DATA_NACK:       // data received, returned nack
     case TW_SR_GCALL_DATA_NACK: // data received generally, returned nack
-      // nack back at master
-      twi_reply(0);
-      break;
+        // nack back at master
+        reply(0);
+        break;
 
     // Slave Transmitter
     case TW_ST_SLA_ACK:          // addressed, returned ack
     case TW_ST_ARB_LOST_SLA_ACK: // arbitration lost, returned ack
-      // enter slave transmitter mode
-      twi_state = TWI_STX;
-      // ready the tx buffer index for iteration
-      twi_txBufferIndex = 0;
-      // set tx buffer length to be zero, to verify if user changes it
-      twi_txBufferLength = 0;
-      // callback to user-defined callback over event task to allow for non-RAM-residing code
-      // request for txBuffer to be filled and length to be set
-      // note: user must call twi_transmit(bytes, length) to do this
-	  ets_post(EVENTTASK_QUEUE_PRIO, TWI_SIG_TX, 0);
-	  break;
+        // enter slave transmitter mode
+        twi_state = TWI_STX;
+        // ready the tx buffer index for iteration
+        twi_txBufferIndex = 0;
+        // set tx buffer length to be zero, to verify if user changes it
+        twi_txBufferLength = 0;
+        // callback to user-defined callback over event task to allow for non-RAM-residing code
+        // request for txBuffer to be filled and length to be set
+        // note: user must call twi_transmit(bytes, length) to do this
+        ets_post(EVENTTASK_QUEUE_PRIO, TWI_SIG_TX, 0);
+        break;
 
-	case TW_ST_DATA_ACK: // byte sent, ack returned
-      // copy data to output register
-      TWDR = twi_txBuffer[twi_txBufferIndex++];
+    case TW_ST_DATA_ACK: // byte sent, ack returned
+        // copy data to output register
+        twi_data = twi_txBuffer[twi_txBufferIndex++];
 
-	  bitCount = 8;
-	  bitCount--;
-	  (twi_data & 0x80) ? SDA_HIGH() : SDA_LOW();
-	  twi_data <<= 1;
+        bitCount = 8;
+        bitCount--;
+        if (twi_data & 0x80)
+        {
+            SDA_HIGH();
+        }
+        else
+        {
+            SDA_LOW();
+        }
+        twi_data <<= 1;
 
-      // if there is more to send, ack, otherwise nack
-      if(twi_txBufferIndex < twi_txBufferLength){
-        twi_reply(1);
-      }else{
-        twi_reply(0);
-      }
-      break;
+        // if there is more to send, ack, otherwise nack
+        if (twi_txBufferIndex < twi_txBufferLength)
+        {
+            reply(1);
+        }
+        else
+        {
+            reply(0);
+        }
+        break;
     case TW_ST_DATA_NACK: // received nack, we are done
     case TW_ST_LAST_DATA: // received ack, but we are done already!
-      // leave slave receiver state
-      twi_releaseBus();
-      break;
+        // leave slave receiver state
+        releaseBus();
+        break;
 
     // All
     case TW_NO_INFO:   // no state information
-      break;
+        break;
     case TW_BUS_ERROR: // bus error, illegal stop/start
-      twi_error = TW_BUS_ERROR;
-      twi_stop();
-      break;
-  }
+        twi_error = TW_BUS_ERROR;
+        stop();
+        break;
+    }
 }
 
-void ICACHE_RAM_ATTR onTimer(void *unused)
+void ICACHE_RAM_ATTR Twi::onTimer(void *unused)
 {
-	(void)unused;
-	twi_releaseBus();
-	twip_status = TW_BUS_ERROR;
-	twi_onTwipEvent(twip_status);
-	twip_mode = TWIPM_WAIT;
-	twip_state = TWIP_BUS_ERR;
+    (void)unused;
+    twi.releaseBus();
+    twi.onTwipEvent(TW_BUS_ERROR);
+    twi.twip_mode = TWIPM_WAIT;
+    twi.twip_state = TWIP_BUS_ERR;
 }
 
-static void eventTask(ETSEvent *e)
+void Twi::eventTask(ETSEvent *e)
 {
 
-	if (e == NULL) {
-		return;
-	}
+    if (e == NULL)
+    {
+        return;
+    }
 
-	switch (e->sig)
-	{
-		case TWI_SIG_TX:
-			twi_onSlaveTransmit();
+    switch (e->sig)
+    {
+    case TWI_SIG_TX:
+        twi.twi_onSlaveTransmit();
 
-			// if they didn't change buffer & length, initialize it
-			if (twi_txBufferLength == 0) {
-				twi_txBufferLength = 1;
-				twi_txBuffer[0] = 0x00;
-			}
+        // if they didn't change buffer & length, initialize it
+        if (twi.twi_txBufferLength == 0)
+        {
+            twi.twi_txBufferLength = 1;
+            twi.twi_txBuffer[0] = 0x00;
+        }
 
-			// Initiate transmission
-			twi_onTwipEvent(TW_ST_DATA_ACK);
+        // Initiate transmission
+        twi.onTwipEvent(TW_ST_DATA_ACK);
 
-			break;
+        break;
 
-		case TWI_SIG_RX:
-			// ack future responses and leave slave receiver state
-			twi_releaseBus();
-			twi_onSlaveReceive(twi_rxBuffer, e->par);
-			break;
-	}
+    case TWI_SIG_RX:
+        // ack future responses and leave slave receiver state
+        twi.releaseBus();
+        twi.twi_onSlaveReceive(twi.twi_rxBuffer, e->par);
+        break;
+    }
 }
 
-void ICACHE_RAM_ATTR onSclChange(void)
+// The state machine is converted from a 0...15 state to a 1-hot encoded state, and then
+// compared to the logical-or of all states with the same branch.  This removes the need
+// for a large series of straight-line compares.  The biggest win is when multiple states
+// all have the same branch (onSdaChange), but for others there is some benefit, still.
+#define S2M(x) (1<<(x))
+// Shorthand for if the state is any of the or'd bitmask x
+#define IFSTATE(x) if (twip_state_mask & (x))
+
+void ICACHE_RAM_ATTR Twi::onSclChange(void)
 {
-	static uint8_t sda;
-	static uint8_t scl;
+    unsigned int sda;
+    unsigned int scl;
 
-	sda	= SDA_READ();
-	scl = SCL_READ();
+    // Store bool return in int to reduce final code size.
+    sda = twi.SDA_READ();
+    scl = twi.SCL_READ();
 
-	twip_status = 0xF8;		// reset TWI status
+    twi.twip_status = 0xF8;		// reset TWI status
 
-	switch (twip_state)
-	{
-		case TWIP_IDLE:
-		case TWIP_WAIT_STOP:
-		case TWIP_BUS_ERR:
-			// ignore
-			break;
+    int twip_state_mask = S2M(twi.twip_state);
+    IFSTATE(S2M(TWIP_START) | S2M(TWIP_REP_START) | S2M(TWIP_SLA_W) | S2M(TWIP_READ))
+    {
+        if (!scl)
+        {
+            // ignore
+        }
+        else
+        {
+            twi.bitCount--;
+            twi.twi_data <<= 1;
+            twi.twi_data |= sda;
 
-		case TWIP_START:
-		case TWIP_REP_START:
-		case TWIP_SLA_W:
-		case TWIP_READ:
-			if (!scl) {
-				// ignore
-			} else {
-				bitCount--;
-				twi_data <<= 1;
-				twi_data |= sda;
+            if (twi.bitCount != 0)
+            {
+                // continue
+            }
+            else
+            {
+                twi.twip_state = TWIP_SEND_ACK;
+            }
+        }
+    }
+    else IFSTATE(S2M(TWIP_SEND_ACK))
+    {
+        if (scl)
+        {
+            // ignore
+        }
+        else
+        {
+            if (twi.twip_mode == TWIPM_IDLE)
+            {
+                if ((twi.twi_data & 0xFE) != twi.twi_addr)
+                {
+                    // ignore
+                }
+                else
+                {
+                    twi.SDA_LOW();
+                }
+            }
+            else
+            {
+                if (!twi.twi_ack)
+                {
+                    // ignore
+                }
+                else
+                {
+                    twi.SDA_LOW();
+                }
+            }
+            twi.twip_state = TWIP_WAIT_ACK;
+        }
+    }
+    else IFSTATE(S2M(TWIP_WAIT_ACK))
+    {
+        if (scl)
+        {
+            // ignore
+        }
+        else
+        {
+            if (twi.twip_mode == TWIPM_IDLE)
+            {
+                if ((twi.twi_data & 0xFE) != twi.twi_addr)
+                {
+                    twi.SDA_HIGH();
+                    twi.twip_state = TWIP_WAIT_STOP;
+                }
+                else
+                {
+                    twi.SCL_LOW();	// clock stretching
+                    twi.SDA_HIGH();
+                    twi.twip_mode = TWIPM_ADDRESSED;
+                    if (!(twi.twi_data & 0x01))
+                    {
+                        twi.onTwipEvent(TW_SR_SLA_ACK);
+                        twi.bitCount = 8;
+                        twi.twip_state = TWIP_SLA_W;
+                    }
+                    else
+                    {
+                        twi.onTwipEvent(TW_ST_SLA_ACK);
+                        twi.twip_state = TWIP_SLA_R;
+                    }
+                }
+            }
+            else
+            {
+                twi.SCL_LOW();	// clock stretching
+                twi.SDA_HIGH();
+                if (!twi.twi_ack)
+                {
+                    twi.onTwipEvent(TW_SR_DATA_NACK);
+                    twi.twip_mode = TWIPM_WAIT;
+                    twi.twip_state = TWIP_WAIT_STOP;
+                }
+                else
+                {
+                    twi.onTwipEvent(TW_SR_DATA_ACK);
+                    twi.bitCount = 8;
+                    twi.twip_state = TWIP_READ;
+                }
+            }
+        }
+    }
+    else IFSTATE(S2M(TWIP_SLA_R) | S2M(TWIP_WRITE))
+    {
+        if (scl)
+        {
+            // ignore
+        }
+        else
+        {
+            twi.bitCount--;
+            if (twi.twi_data & 0x80)
+            {
+                twi.SDA_HIGH();
+            }
+            else
+            {
+                twi.SDA_LOW();
+            }
+            twi.twi_data <<= 1;
 
-				if (bitCount != 0) {
-					// continue
-				} else {
-					twip_state = TWIP_SEND_ACK;
-				}
-			}
-			break;
-
-		case TWIP_SEND_ACK:
-			if (scl) {
-				// ignore
-			} else {
-				if (twip_mode == TWIPM_IDLE) {
-					if ((twi_data & 0xFE) != twi_addr) {
-						// ignore
-					} else {
-						SDA_LOW();
-					}
-				} else {
-					if (!twi_ack) {
-						// ignore
-					} else {
-						SDA_LOW();
-					}
-				}
-				twip_state = TWIP_WAIT_ACK;
-			}
-			break;
-
-		case TWIP_WAIT_ACK:
-			if (scl) {
-				// ignore
-			} else {
-				if (twip_mode == TWIPM_IDLE) {
-					if ((twi_data & 0xFE) != twi_addr) {
-						SDA_HIGH();
-						twip_state = TWIP_WAIT_STOP;
-					} else {
-						SCL_LOW();	// clock stretching
-						SDA_HIGH();
-						twip_mode = TWIPM_ADDRESSED;
-						if (!(twi_data & 0x01)) {
-							twip_status = TW_SR_SLA_ACK;
-							twi_onTwipEvent(twip_status);
-							bitCount = 8;
-							twip_state = TWIP_SLA_W;
-						} else {
-							twip_status = TW_ST_SLA_ACK;
-							twi_onTwipEvent(twip_status);
-							twip_state = TWIP_SLA_R;
-						}
-					}
-				} else {
-					SCL_LOW();	// clock stretching
-					SDA_HIGH();
-					if (!twi_ack) {
-						twip_status = TW_SR_DATA_NACK;
-						twi_onTwipEvent(twip_status);
-						twip_mode = TWIPM_WAIT;
-						twip_state = TWIP_WAIT_STOP;
-					} else {
-						twip_status = TW_SR_DATA_ACK;
-						twi_onTwipEvent(twip_status);
-						bitCount = 8;
-						twip_state = TWIP_READ;
-					}
-				}
-			}
-			break;
-
-		case TWIP_SLA_R:
-		case TWIP_WRITE:
-			if (scl) {
-				// ignore
-			} else {
-				bitCount--;
-				(twi_data & 0x80) ? SDA_HIGH() : SDA_LOW();
-				twi_data <<= 1;
-
-				if (bitCount != 0) {
-					// continue
-				} else {
-					twip_state = TWIP_REC_ACK;
-				}
-			}
-			break;
-
-		case TWIP_REC_ACK:
-			if (scl) {
-				// ignore
-			} else {
-				SDA_HIGH();
-				twip_state = TWIP_READ_ACK;
-			}
-			break;
-
-		case TWIP_READ_ACK:
-			if (!scl) {
-				// ignore
-			} else {
-				twi_ack_rec = !sda;
-				twip_state = TWIP_RWAIT_ACK;
-			}
-			break;
-
-		case TWIP_RWAIT_ACK:
-			if (scl) {
-				// ignore
-			} else {
-				SCL_LOW();	// clock stretching
-				if (twi_ack && twi_ack_rec) {
-					twip_status = TW_ST_DATA_ACK;
-					twi_onTwipEvent(twip_status);
-					twip_state = TWIP_WRITE;
-				} else {
-					// we have no more data to send and/or the master doesn't want anymore
-					twip_status = twi_ack_rec ? TW_ST_LAST_DATA : TW_ST_DATA_NACK;
-					twi_onTwipEvent(twip_status);
-					twip_mode = TWIPM_WAIT;
-					twip_state = TWIP_WAIT_STOP;
-				}
-			}
-			break;
-
-		default:
-			break;
-	}
+            if (twi.bitCount != 0)
+            {
+                // continue
+            }
+            else
+            {
+                twi.twip_state = TWIP_REC_ACK;
+            }
+        }
+    }
+    else IFSTATE(S2M(TWIP_REC_ACK))
+    {
+        if (scl)
+        {
+            // ignore
+        }
+        else
+        {
+            twi.SDA_HIGH();
+            twi.twip_state = TWIP_READ_ACK;
+        }
+    }
+    else IFSTATE(S2M(TWIP_READ_ACK))
+    {
+        if (!scl)
+        {
+            // ignore
+        }
+        else
+        {
+            twi.twi_ack_rec = !sda;
+            twi.twip_state = TWIP_RWAIT_ACK;
+        }
+    }
+    else IFSTATE(S2M(TWIP_RWAIT_ACK))
+    {
+        if (scl)
+        {
+            // ignore
+        }
+        else
+        {
+            twi.SCL_LOW();	// clock stretching
+            if (twi.twi_ack && twi.twi_ack_rec)
+            {
+                twi.onTwipEvent(TW_ST_DATA_ACK);
+                twi.twip_state = TWIP_WRITE;
+            }
+            else
+            {
+                // we have no more data to send and/or the master doesn't want anymore
+                twi.onTwipEvent(twi.twi_ack_rec ? TW_ST_LAST_DATA : TW_ST_DATA_NACK);
+                twi.twip_mode = TWIPM_WAIT;
+                twi.twip_state = TWIP_WAIT_STOP;
+            }
+        }
+    }
 }
 
-void ICACHE_RAM_ATTR onSdaChange(void)
+void ICACHE_RAM_ATTR Twi::onSdaChange(void)
 {
-	static uint8_t sda;
-	static uint8_t scl;
-	sda	= SDA_READ();
-	scl = SCL_READ();
+    unsigned int sda;
+    unsigned int scl;
 
-	switch (twip_state)
-	{
-		case TWIP_IDLE:
-			if (!scl) {
-				// DATA - ignore
-			} else if (sda) {
-				// STOP - ignore
-			} else {
-				// START
-				bitCount = 8;
-				twip_state = TWIP_START;
-				ets_timer_arm_new(&timer, twi_timeout_ms, false, true); // Once, ms
-			}
-			break;
+    // Store bool return in int to reduce final code size.
+    sda = twi.SDA_READ();
+    scl = twi.SCL_READ();
 
-		case TWIP_START:
-		case TWIP_REP_START:
-		case TWIP_SEND_ACK:
-		case TWIP_WAIT_ACK:
-		case TWIP_SLA_R:
-		case TWIP_REC_ACK:
-		case TWIP_READ_ACK:
-		case TWIP_RWAIT_ACK:
-		case TWIP_WRITE:
-			if (!scl) {
-				// DATA - ignore
-			} else {
-				// START or STOP
-				SDA_HIGH();	 // Should not be necessary
-				twip_status = TW_BUS_ERROR;
-				twi_onTwipEvent(twip_status);
-				twip_mode = TWIPM_WAIT;
-				twip_state = TWIP_BUS_ERR;
-			}
-			break;
-
-		case TWIP_WAIT_STOP:
-		case TWIP_BUS_ERR:
-			if (!scl) {
-				// DATA - ignore
-			} else {
-				if (sda) {
-					// STOP
-					SCL_LOW();	// clock stretching
-					ets_timer_disarm(&timer);
-					twip_state = TWIP_IDLE;
-					twip_mode = TWIPM_IDLE;
-					SCL_HIGH();
-				} else {
-					// START
-					if (twip_state == TWIP_BUS_ERR) {
-						// ignore
-					} else {
-						bitCount = 8;
-						twip_state = TWIP_REP_START;
-						ets_timer_arm_new(&timer, twi_timeout_ms, false, true); // Once, ms
-					}
-				}
-			}
-			break;
-
-		case TWIP_SLA_W:
-		case TWIP_READ:
-			if (!scl) {
-				// DATA - ignore
-			} else {
-				// START or STOP
-				if (bitCount != 7) {
-					// inside byte transfer - error
-					twip_status = TW_BUS_ERROR;
-					twi_onTwipEvent(twip_status);
-					twip_mode = TWIPM_WAIT;
-					twip_state = TWIP_BUS_ERR;
-				} else {
-					// during first bit in byte transfer - ok
-					SCL_LOW();	// clock stretching
-					twip_status = TW_SR_STOP;
-					twi_onTwipEvent(twip_status);
-					if (sda) {
-						// STOP
-						ets_timer_disarm(&timer);
-						twip_state = TWIP_IDLE;
-						twip_mode = TWIPM_IDLE;
-					} else {
-						// START
-						bitCount = 8;
-						ets_timer_arm_new(&timer, twi_timeout_ms, false, true); // Once, ms
-						twip_state = TWIP_REP_START;
-						twip_mode = TWIPM_IDLE;
-					}
-				}
-			}
-			break;
-
-		default:
-			break;
-	}
+    int twip_state_mask = S2M(twi.twip_state);
+    if (scl)   /* !DATA */
+    {
+        IFSTATE(S2M(TWIP_IDLE))
+        {
+            if (sda)
+            {
+                // STOP - ignore
+            }
+            else
+            {
+                // START
+                twi.bitCount = 8;
+                twi.twip_state = TWIP_START;
+                ets_timer_arm_new(&twi.timer, twi.twi_timeout_ms, false, true); // Once, ms
+            }
+        }
+        else IFSTATE(S2M(TWIP_START) | S2M(TWIP_REP_START) | S2M(TWIP_SEND_ACK) | S2M(TWIP_WAIT_ACK) | S2M(TWIP_SLA_R) | S2M(TWIP_REC_ACK) | S2M(TWIP_READ_ACK) | S2M(TWIP_RWAIT_ACK) | S2M(TWIP_WRITE))
+        {
+            // START or STOP
+            twi.SDA_HIGH();	 // Should not be necessary
+            twi.onTwipEvent(TW_BUS_ERROR);
+            twi.twip_mode = TWIPM_WAIT;
+            twi.twip_state = TWIP_BUS_ERR;
+        }
+        else IFSTATE(S2M(TWIP_WAIT_STOP) | S2M(TWIP_BUS_ERR))
+        {
+            if (sda)
+            {
+                // STOP
+                twi.SCL_LOW();	// clock stretching
+                ets_timer_disarm(&twi.timer);
+                twi.twip_state = TWIP_IDLE;
+                twi.twip_mode = TWIPM_IDLE;
+                twi.SCL_HIGH();
+            }
+            else
+            {
+                // START
+                if (twi.twip_state == TWIP_BUS_ERR)
+                {
+                    // ignore
+                }
+                else
+                {
+                    twi.bitCount = 8;
+                    twi.twip_state = TWIP_REP_START;
+                    ets_timer_arm_new(&twi.timer, twi.twi_timeout_ms, false, true); // Once, ms
+                }
+            }
+        }
+        else IFSTATE(S2M(TWIP_SLA_W) | S2M(TWIP_READ))
+        {
+            // START or STOP
+            if (twi.bitCount != 7)
+            {
+                // inside byte transfer - error
+                twi.onTwipEvent(TW_BUS_ERROR);
+                twi.twip_mode = TWIPM_WAIT;
+                twi.twip_state = TWIP_BUS_ERR;
+            }
+            else
+            {
+                // during first bit in byte transfer - ok
+                twi.SCL_LOW();	// clock stretching
+                twi.onTwipEvent(TW_SR_STOP);
+                if (sda)
+                {
+                    // STOP
+                    ets_timer_disarm(&twi.timer);
+                    twi.twip_state = TWIP_IDLE;
+                    twi.twip_mode = TWIPM_IDLE;
+                }
+                else
+                {
+                    // START
+                    twi.bitCount = 8;
+                    ets_timer_arm_new(&twi.timer, twi.twi_timeout_ms, false, true); // Once, ms
+                    twi.twip_state = TWIP_REP_START;
+                    twi.twip_mode = TWIPM_IDLE;
+                }
+            }
+        }
+    }
 }
+
+// C wrappers for the object, since API is exposed only as C
+extern "C" {
+
+    void twi_init(unsigned char sda, unsigned char scl)
+    {
+        return twi.init(sda, scl);
+    }
+
+    void twi_setAddress(uint8_t a)
+    {
+        return twi.setAddress(a);
+    }
+
+    void twi_stop(void)
+    {
+        twi.stop();
+    }
+
+    void twi_setClock(unsigned int freq)
+    {
+        twi.setClock(freq);
+    }
+
+    void twi_setClockStretchLimit(uint32_t limit)
+    {
+        twi.setClockStretchLimit(limit);
+    }
+
+    uint8_t twi_writeTo(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop)
+    {
+        return twi.writeTo(address, buf, len, sendStop);
+    }
+
+    uint8_t twi_readFrom(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop)
+    {
+        return twi.readFrom(address, buf, len, sendStop);
+    }
+
+    uint8_t twi_status()
+    {
+        return twi.status();
+    }
+
+    uint8_t twi_transmit(const uint8_t * buf, uint8_t len)
+    {
+        return twi.transmit(buf, len);
+    }
+
+    void twi_attachSlaveRxEvent(void (*cb)(uint8_t*, size_t))
+    {
+        twi.attachSlaveRxEvent(cb);
+    }
+
+    void twi_attachSlaveTxEvent(void (*cb)(void))
+    {
+        twi.attachSlaveTxEvent(cb);
+    }
+
+    void twi_reply(uint8_t r)
+    {
+        twi.reply(r);
+    }
+
+    void twi_releaseBus(void)
+    {
+        twi.releaseBus();
+    }
+
+    void twi_enableSlaveMode(void)
+    {
+        twi.enableSlave();
+    }
 
 };

--- a/cores/esp8266/twi.h
+++ b/cores/esp8266/twi.h
@@ -1,23 +1,23 @@
 /*
-  twi.h - Software I2C library for esp8266
+    twi.h - Software I2C library for esp8266
 
-  Copyright (c) 2015 Hristo Gochkov. All rights reserved.
-  This file is part of the esp8266 core for Arduino environment.
+    Copyright (c) 2015 Hristo Gochkov. All rights reserved.
+    This file is part of the esp8266 core for Arduino environment.
 
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation; either
-  version 2.1 of the License, or (at your option) any later version.
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
 
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
 
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-  Modified January 2017 by Bjorn Hammarberg (bjoham@esp8266.com) - i2c slave support
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+    Modified January 2017 by Bjorn Hammarberg (bjoham@esp8266.com) - i2c slave support
 */
 #ifndef SI2C_h
 #define SI2C_h
@@ -48,12 +48,13 @@ uint8_t twi_status();
 
 uint8_t twi_transmit(const uint8_t*, uint8_t);
 
-void twi_attachSlaveRxEvent( void (*)(uint8_t*, size_t) );
-void twi_attachSlaveTxEvent( void (*)(void) );
+void twi_attachSlaveRxEvent(void (*)(uint8_t*, size_t));
+void twi_attachSlaveTxEvent(void (*)(void));
 void twi_reply(uint8_t);
 //void twi_stop(void);
 void twi_releaseBus(void);
 
+void twi_enableSlaveMode(void);
 
 #ifdef __cplusplus
 }

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -1,31 +1,31 @@
 /*
-  TwoWire.cpp - TWI/I2C library for Arduino & Wiring
-  Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+    TwoWire.cpp - TWI/I2C library for Arduino & Wiring
+    Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
 
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation; either
-  version 2.1 of the License, or (at your option) any later version.
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
 
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
 
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-  Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
-  Modified December 2014 by Ivan Grokhotkov (ivan@esp8266.com) - esp8266 support
-  Modified April 2015 by Hrsto Gochkov (ficeto@ficeto.com) - alternative esp8266 support
-  Modified January 2017 by Bjorn Hammarberg (bjoham@esp8266.com) - i2c slave support
+    Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+    Modified December 2014 by Ivan Grokhotkov (ivan@esp8266.com) - esp8266 support
+    Modified April 2015 by Hrsto Gochkov (ficeto@ficeto.com) - alternative esp8266 support
+    Modified January 2017 by Bjorn Hammarberg (bjoham@esp8266.com) - i2c slave support
 */
 
 extern "C" {
-  #include <stdlib.h>
-  #include <string.h>
-  #include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
 }
 
 #include "twi.h"
@@ -58,226 +58,273 @@ static int default_scl_pin = SCL;
 
 // Constructors ////////////////////////////////////////////////////////////////
 
-TwoWire::TwoWire(){}
+TwoWire::TwoWire() {}
 
 // Public Methods //////////////////////////////////////////////////////////////
 
-void TwoWire::begin(int sda, int scl){
-  default_sda_pin = sda;
-  default_scl_pin = scl;
-  twi_init(sda, scl);
-  flush();
+void TwoWire::begin(int sda, int scl)
+{
+    default_sda_pin = sda;
+    default_scl_pin = scl;
+    twi_init(sda, scl);
+    flush();
 }
 
-void TwoWire::begin(int sda, int scl, uint8_t address){
-  default_sda_pin = sda;
-  default_scl_pin = scl;
-  twi_setAddress(address);
-  twi_init(sda, scl);
-  twi_attachSlaveTxEvent(onRequestService);
-  twi_attachSlaveRxEvent(onReceiveService);
-  flush();
+void TwoWire::begin(int sda, int scl, uint8_t address)
+{
+    default_sda_pin = sda;
+    default_scl_pin = scl;
+    twi_setAddress(address);
+    twi_init(sda, scl);
+    twi_attachSlaveTxEvent(onRequestService);
+    twi_attachSlaveRxEvent(onReceiveService);
+    flush();
 }
 
-void TwoWire::pins(int sda, int scl){
-  default_sda_pin = sda;
-  default_scl_pin = scl;
+void TwoWire::pins(int sda, int scl)
+{
+    default_sda_pin = sda;
+    default_scl_pin = scl;
 }
 
-void TwoWire::begin(void){
-  begin(default_sda_pin, default_scl_pin);
+void TwoWire::begin(void)
+{
+    begin(default_sda_pin, default_scl_pin);
 }
 
-void TwoWire::begin(uint8_t address){
-  twi_setAddress(address);
-  twi_attachSlaveTxEvent(onRequestService);
-  twi_attachSlaveRxEvent(onReceiveService);
-  begin();
+void TwoWire::begin(uint8_t address)
+{
+    twi_setAddress(address);
+    twi_attachSlaveTxEvent(onRequestService);
+    twi_attachSlaveRxEvent(onReceiveService);
+    begin();
 }
 
-uint8_t TwoWire::status(){
-	return twi_status();
+uint8_t TwoWire::status()
+{
+    return twi_status();
 }
 
-void TwoWire::begin(int address){
-  begin((uint8_t)address);
+void TwoWire::begin(int address)
+{
+    begin((uint8_t)address);
 }
 
-void TwoWire::setClock(uint32_t frequency){
-  twi_setClock(frequency);
+void TwoWire::setClock(uint32_t frequency)
+{
+    twi_setClock(frequency);
 }
 
-void TwoWire::setClockStretchLimit(uint32_t limit){
-  twi_setClockStretchLimit(limit);
+void TwoWire::setClockStretchLimit(uint32_t limit)
+{
+    twi_setClockStretchLimit(limit);
 }
 
-size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop){
-  if(size > BUFFER_LENGTH){
-    size = BUFFER_LENGTH;
-  }
-  size_t read = (twi_readFrom(address, rxBuffer, size, sendStop) == 0)?size:0;
-  rxBufferIndex = 0;
-  rxBufferLength = read;
-  return read;
-}
-
-uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop){
-  return requestFrom(address, static_cast<size_t>(quantity), static_cast<bool>(sendStop));
-}
-
-uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity){
-  return requestFrom(address, static_cast<size_t>(quantity), true);
-}
-
-uint8_t TwoWire::requestFrom(int address, int quantity){
-  return requestFrom(static_cast<uint8_t>(address), static_cast<size_t>(quantity), true);
-}
-
-uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop){
-  return requestFrom(static_cast<uint8_t>(address), static_cast<size_t>(quantity), static_cast<bool>(sendStop));
-}
-
-void TwoWire::beginTransmission(uint8_t address){
-  transmitting = 1;
-  txAddress = address;
-  txBufferIndex = 0;
-  txBufferLength = 0;
-}
-
-void TwoWire::beginTransmission(int address){
-  beginTransmission((uint8_t)address);
-}
-
-uint8_t TwoWire::endTransmission(uint8_t sendStop){
-  int8_t ret = twi_writeTo(txAddress, txBuffer, txBufferLength, sendStop);
-  txBufferIndex = 0;
-  txBufferLength = 0;
-  transmitting = 0;
-  return ret;
-}
-
-uint8_t TwoWire::endTransmission(void){
-  return endTransmission(true);
-}
-
-size_t TwoWire::write(uint8_t data){
-  if(transmitting){
-    if(txBufferLength >= BUFFER_LENGTH){
-      setWriteError();
-      return 0;
+size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop)
+{
+    if (size > BUFFER_LENGTH)
+    {
+        size = BUFFER_LENGTH;
     }
-    txBuffer[txBufferIndex] = data;
-    ++txBufferIndex;
-    txBufferLength = txBufferIndex;
-  } else {
-    twi_transmit(&data, 1);
-  }
-  return 1;
+    size_t read = (twi_readFrom(address, rxBuffer, size, sendStop) == 0) ? size : 0;
+    rxBufferIndex = 0;
+    rxBufferLength = read;
+    return read;
 }
 
-size_t TwoWire::write(const uint8_t *data, size_t quantity){
-  if(transmitting){
-    for(size_t i = 0; i < quantity; ++i){
-      if(!write(data[i])) return i;
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop)
+{
+    return requestFrom(address, static_cast<size_t>(quantity), static_cast<bool>(sendStop));
+}
+
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity)
+{
+    return requestFrom(address, static_cast<size_t>(quantity), true);
+}
+
+uint8_t TwoWire::requestFrom(int address, int quantity)
+{
+    return requestFrom(static_cast<uint8_t>(address), static_cast<size_t>(quantity), true);
+}
+
+uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop)
+{
+    return requestFrom(static_cast<uint8_t>(address), static_cast<size_t>(quantity), static_cast<bool>(sendStop));
+}
+
+void TwoWire::beginTransmission(uint8_t address)
+{
+    transmitting = 1;
+    txAddress = address;
+    txBufferIndex = 0;
+    txBufferLength = 0;
+}
+
+void TwoWire::beginTransmission(int address)
+{
+    beginTransmission((uint8_t)address);
+}
+
+uint8_t TwoWire::endTransmission(uint8_t sendStop)
+{
+    int8_t ret = twi_writeTo(txAddress, txBuffer, txBufferLength, sendStop);
+    txBufferIndex = 0;
+    txBufferLength = 0;
+    transmitting = 0;
+    return ret;
+}
+
+uint8_t TwoWire::endTransmission(void)
+{
+    return endTransmission(true);
+}
+
+size_t TwoWire::write(uint8_t data)
+{
+    if (transmitting)
+    {
+        if (txBufferLength >= BUFFER_LENGTH)
+        {
+            setWriteError();
+            return 0;
+        }
+        txBuffer[txBufferIndex] = data;
+        ++txBufferIndex;
+        txBufferLength = txBufferIndex;
     }
-  }else{
-    twi_transmit(data, quantity);
-  }
-  return quantity;
+    else
+    {
+        twi_transmit(&data, 1);
+    }
+    return 1;
 }
 
-int TwoWire::available(void){
-  int result = rxBufferLength - rxBufferIndex;
-
-  if (!result) {
-    // yielding here will not make more data "available",
-    // but it will prevent the system from going into WDT reset
-    optimistic_yield(1000);
-  }
-
-  return result;
+size_t TwoWire::write(const uint8_t *data, size_t quantity)
+{
+    if (transmitting)
+    {
+        for (size_t i = 0; i < quantity; ++i)
+        {
+            if (!write(data[i]))
+            {
+                return i;
+            }
+        }
+    }
+    else
+    {
+        twi_transmit(data, quantity);
+    }
+    return quantity;
 }
 
-int TwoWire::read(void){
-  int value = -1;
-  if(rxBufferIndex < rxBufferLength){
-    value = rxBuffer[rxBufferIndex];
-    ++rxBufferIndex;
-  }
-  return value;
+int TwoWire::available(void)
+{
+    int result = rxBufferLength - rxBufferIndex;
+
+    if (!result)
+    {
+        // yielding here will not make more data "available",
+        // but it will prevent the system from going into WDT reset
+        optimistic_yield(1000);
+    }
+
+    return result;
 }
 
-int TwoWire::peek(void){
-  int value = -1;
-  if(rxBufferIndex < rxBufferLength){
-    value = rxBuffer[rxBufferIndex];
-  }
-  return value;
+int TwoWire::read(void)
+{
+    int value = -1;
+    if (rxBufferIndex < rxBufferLength)
+    {
+        value = rxBuffer[rxBufferIndex];
+        ++rxBufferIndex;
+    }
+    return value;
 }
 
-void TwoWire::flush(void){
-  rxBufferIndex = 0;
-  rxBufferLength = 0;
-  txBufferIndex = 0;
-  txBufferLength = 0;
+int TwoWire::peek(void)
+{
+    int value = -1;
+    if (rxBufferIndex < rxBufferLength)
+    {
+        value = rxBuffer[rxBufferIndex];
+    }
+    return value;
+}
+
+void TwoWire::flush(void)
+{
+    rxBufferIndex = 0;
+    rxBufferLength = 0;
+    txBufferIndex = 0;
+    txBufferLength = 0;
 }
 
 void TwoWire::onReceiveService(uint8_t* inBytes, size_t numBytes)
 {
-  // don't bother if user hasn't registered a callback
-  if (!user_onReceive) {
-	return;
-  }
-  // // don't bother if rx buffer is in use by a master requestFrom() op
-  // // i know this drops data, but it allows for slight stupidity
-  // // meaning, they may not have read all the master requestFrom() data yet
-  // if(rxBufferIndex < rxBufferLength){
-  //   return;
-  // }
-  
-  // copy twi rx buffer into local read buffer
-  // this enables new reads to happen in parallel
-  for (uint8_t i = 0; i < numBytes; ++i) {
-	rxBuffer[i] = inBytes[i];
-  }
-  
-  // set rx iterator vars
-  rxBufferIndex = 0;
-  rxBufferLength = numBytes;
-  
-  // alert user program
-  user_onReceive(numBytes);
+    // don't bother if user hasn't registered a callback
+    if (!user_onReceive)
+    {
+        return;
+    }
+    // // don't bother if rx buffer is in use by a master requestFrom() op
+    // // i know this drops data, but it allows for slight stupidity
+    // // meaning, they may not have read all the master requestFrom() data yet
+    // if(rxBufferIndex < rxBufferLength){
+    //   return;
+    // }
+
+    // copy twi rx buffer into local read buffer
+    // this enables new reads to happen in parallel
+    for (uint8_t i = 0; i < numBytes; ++i)
+    {
+        rxBuffer[i] = inBytes[i];
+    }
+
+    // set rx iterator vars
+    rxBufferIndex = 0;
+    rxBufferLength = numBytes;
+
+    // alert user program
+    user_onReceive(numBytes);
 }
 
 void TwoWire::onRequestService(void)
 {
-	// don't bother if user hasn't registered a callback
-	if (!user_onRequest) {
-		return;
-	}
-	
-	// reset tx buffer iterator vars
-	// !!! this will kill any pending pre-master sendTo() activity
-	txBufferIndex = 0;
-	txBufferLength = 0;
-	
-	// alert user program
-	user_onRequest();
+    // don't bother if user hasn't registered a callback
+    if (!user_onRequest)
+    {
+        return;
+    }
+
+    // reset tx buffer iterator vars
+    // !!! this will kill any pending pre-master sendTo() activity
+    txBufferIndex = 0;
+    txBufferLength = 0;
+
+    // alert user program
+    user_onRequest();
 }
 
-void TwoWire::onReceive( void (*function)(int) ) {
-  // arduino api compatibility fixer:
-  // really hope size parameter will not exceed 2^31 :)
-  static_assert(sizeof(int) == sizeof(size_t), "something is wrong in Arduino kingdom");
-  user_onReceive = reinterpret_cast<void(*)(size_t)>(function);
+void TwoWire::onReceive(void (*function)(int))
+{
+    // arduino api compatibility fixer:
+    // really hope size parameter will not exceed 2^31 :)
+    static_assert(sizeof(int) == sizeof(size_t), "something is wrong in Arduino kingdom");
+    user_onReceive = reinterpret_cast<void(*)(size_t)>(function);
 }
 
-void TwoWire::onReceive( void (*function)(size_t) ) {
-  user_onReceive = function;
+void TwoWire::onReceive(void (*function)(size_t))
+{
+    user_onReceive = function;
+    twi_enableSlaveMode();
 }
 
-void TwoWire::onRequest( void (*function)(void) ){
-  user_onRequest = function;
+void TwoWire::onRequest(void (*function)(void))
+{
+    user_onRequest = function;
+    twi_enableSlaveMode();
 }
 
 // Preinstantiate Objects //////////////////////////////////////////////////////

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -1,24 +1,24 @@
 /*
-  TwoWire.h - TWI/I2C library for Arduino & Wiring
-  Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+    TwoWire.h - TWI/I2C library for Arduino & Wiring
+    Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
 
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation; either
-  version 2.1 of the License, or (at your option) any later version.
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
 
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
 
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-  Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
-  Modified December 2014 by Ivan Grokhotkov (ivan@esp8266.com) - esp8266 support
-  Modified April 2015 by Hrsto Gochkov (ficeto@ficeto.com) - alternative esp8266 support
+    Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+    Modified December 2014 by Ivan Grokhotkov (ivan@esp8266.com) - esp8266 support
+    Modified April 2015 by Hrsto Gochkov (ficeto@ficeto.com) - alternative esp8266 support
 */
 
 #ifndef TwoWire_h
@@ -33,7 +33,7 @@
 
 class TwoWire : public Stream
 {
-  private:
+private:
     static uint8_t rxBuffer[];
     static uint8_t rxBufferIndex;
     static uint8_t rxBufferLength;
@@ -48,10 +48,10 @@ class TwoWire : public Stream
     static void (*user_onReceive)(size_t);
     static void onRequestService(void);
     static void onReceiveService(uint8_t*, size_t);
-  public:
+public:
     TwoWire();
     void begin(int sda, int scl);
-    void begin(int sda, int scl, uint8_t address);    
+    void begin(int sda, int scl, uint8_t address);
     void pins(int sda, int scl) __attribute__((deprecated)); // use begin(sda, scl) in new code
     void begin();
     void begin(uint8_t);
@@ -63,22 +63,22 @@ class TwoWire : public Stream
     uint8_t endTransmission(void);
     uint8_t endTransmission(uint8_t);
     size_t requestFrom(uint8_t address, size_t size, bool sendStop);
-	uint8_t status();
+    uint8_t status();
 
     uint8_t requestFrom(uint8_t, uint8_t);
     uint8_t requestFrom(uint8_t, uint8_t, uint8_t);
     uint8_t requestFrom(int, int);
     uint8_t requestFrom(int, int, int);
-    
+
     virtual size_t write(uint8_t);
     virtual size_t write(const uint8_t *, size_t);
     virtual int available(void);
     virtual int read(void);
     virtual int peek(void);
     virtual void flush(void);
-    void onReceive( void (*)(int) );    // arduino api
-    void onReceive( void (*)(size_t) ); // legacy esp8266 backward compatibility
-    void onRequest( void (*)(void) );
+    void onReceive(void (*)(int));      // arduino api
+    void onReceive(void (*)(size_t));   // legacy esp8266 backward compatibility
+    void onRequest(void (*)(void));
 
     using Print::write;
 };

--- a/tests/restyle.sh
+++ b/tests/restyle.sh
@@ -9,7 +9,11 @@ test -d cores/esp8266
 test -d libraries
 
 #all="cores/esp8266 libraries"
-all="libraries/ESP8266mDNS"
+all="
+libraries/ESP8266mDNS
+libraries/Wire
+cores/esp8266/core_esp8266_si2c.cpp
+"
 
 for d in $all; do
     for e in c cpp h; do


### PR DESCRIPTION
* Reduce the IRAM (and heap) usage of I2C code

The I2C code takes a large chunk of IRAM space.  Attempt to reduce the
size of the routines without impacting functionality.

First, remove the `static` classifier on the sda/scl variables in the
event handlers.  The first instructions in the routines overwrite the
last value stored in them, anyway, and their addresses are never taken.

* Make most variables ints, not uint8_ts

Where it doesn't make a functional difference, make global variables
ints and not unit8_t.  Bytewide updates and extracts require multiple
instructions and hence increase IRAM usage as well as runtime.

* Make local flag vars int

Sketch uses 270855 bytes (25%) of program storage space. Maximum is 1044464 bytes.
Global variables use 27940 bytes (34%) of dynamic memory, leaving 53980 bytes for local variables. Maximum is 81920 bytes.
./xtensa-lx106-elf/bin/xtensa-lx106-elf-objdump -t  -j .text1 /tmp/arduino_build_9615/*elf | sort -k1 | head -20
401000cc l     F .text1	00000014 twi_delay
401000ec l     F .text1	00000020 twi_reply$part$1
4010010c g     F .text1	00000035 twi_reply
4010014c g     F .text1	00000052 twi_stop
401001a0 g     F .text1	0000003b twi_releaseBus
40100204 g     F .text1	000001e6 twi_onTwipEvent
40100404 l     F .text1	000001f7 onSdaChange
40100608 l     F .text1	000002fd onSclChange
40100908 l     F .text1	0000003b onTimer

* Factor out !scl in onSdaChange

If SCL is low then all branches of the case are no-ops, so factor that
portion outo to remove some redundant logic in each case.

Sketch uses 270843 bytes (25%) of program storage space. Maximum is 1044464 bytes.
Global variables use 27944 bytes (34%) of dynamic memory, leaving 53976 bytes for local variables. Maximum is 81920 bytes.

401000cc l     F .text1	00000014 twi_delay
401000ec l     F .text1	00000020 twi_reply$part$1
4010010c g     F .text1	00000035 twi_reply
4010014c g     F .text1	00000052 twi_stop
401001a0 g     F .text1	0000003b twi_releaseBus
40100204 g     F .text1	000001e6 twi_onTwipEvent
40100404 l     F .text1	000001e7 onSdaChange
401005f8 l     F .text1	000002fd onSclChange
401008f8 l     F .text1	0000003b onTimer

0x0000000040107468                _text_end = ABSOLUTE (.)

* Make tiny twi_reply inline

twi_reply is a chunk of code that can be inlined and actually save IRAM
space because certain conditions acan be statically evaluated by gcc.

Sketch uses 270823 bytes (25%) of program storage space. Maximum is 1044464 bytes.
Global variables use 27944 bytes (34%) of dynamic memory, leaving 53976 bytes for local variables. Maximum is 81920 bytes.

401000cc l     F .text1	00000014 twi_delay
401000f4 g     F .text1	00000052 twi_stop
40100148 g     F .text1	0000003b twi_releaseBus
401001b0 g     F .text1	00000206 twi_onTwipEvent
401003d0 l     F .text1	000001e7 onSdaChange
401005c4 l     F .text1	000002fd onSclChange
401008c4 l     F .text1	0000003b onTimer
40100918 g     F .text1	00000085 millis
401009a0 g     F .text1	0000000f micros
401009b0 g     F .text1	00000022 micros64
401009d8 g     F .text1	00000013 delayMicroseconds
401009f0 g     F .text1	00000034 __digitalRead
401009f0  w    F .text1	00000034 digitalRead
40100a3c g     F .text1	000000e4 interrupt_handler
40100b20 g     F .text1	0000000f vPortFree

0x0000000040107434                _text_end = ABSOLUTE (.)

* Inline additional twi_** helper functions

Sketch uses 270799 bytes (25%) of program storage space. Maximum is 1044464 bytes.
Global variables use 27944 bytes (34%) of dynamic memory, leaving 53976 bytes for local variables. Maximum is 81920 bytes.

401000cc l     F .text1	00000014 twi_delay
401000f4  w    F .text1	0000003b twi_releaseBus
4010015c g     F .text1	00000246 twi_onTwipEvent
401003bc l     F .text1	000001e7 onSdaChange
401005b0 l     F .text1	000002f9 onSclChange
401008ac l     F .text1	0000003b onTimer

0x000000004010741c                _text_end = ABSOLUTE (.)

* Convert state machine to 1-hot for faster lookup

GCC won't use a lookup table for the TWI state machine, so it ends up
using a series of straight line compare-jump, compare-jumps to figure
out which branch of code to execute for each state.  For branches that
have multiple states that call them, this can expand to a lot of code.

Short-circuit the whole thing by converting the FSM to a 1-hot encoding
while executing it, and then just and-ing the 1-hot state with the
bitmask of states with the same code.

Sketch uses 270719 bytes (25%) of program storage space. Maximum is 1044464 bytes.
Global variables use 27944 bytes (34%) of dynamic memory, leaving 53976 bytes for local variables. Maximum is 81920 bytes.

401000cc l     F .text1	00000014 twi_delay
401000f4  w    F .text1	0000003b twi_releaseBus
4010015c g     F .text1	00000246 twi_onTwipEvent
401003c0 l     F .text1	000001b1 onSdaChange
40100580 l     F .text1	000002da onSclChange
4010085c l     F .text1	0000003b onTimer

0x00000000401073cc                _text_end = ABSOLUTE (.)

Saves 228 bytes of IRAM vs. master, uses 32 additional bytes of heap.

* Factor out twi_status setting

twi_status is set immediately before  an event handler is called,
resulting in lots of duplicated code.  Set the twi_status flag inside
the handler itself.

Saves an add'l ~100 bytes of IRAM from prior changes, for a total of
~340 bytes.

earle@server:~/Arduino/hardware/esp8266com/esp8266/tools$ ./xtensa-lx106-elf/bin/xtensa-lx106-elf-objdump -t  -j .text1 /tmp/arduino_build_849115/*elf | sort -k1 | head -20

401000cc l     F .text1	00000014 twi_delay
401000f4  w    F .text1	0000003b twi_releaseBus
40100160 g     F .text1	0000024e twi_onTwipEvent
401003c8 l     F .text1	00000181 onSdaChange
40100558 l     F .text1	00000297 onSclChange

* Use a struct to hold globals for TWI

Thanks to the suggestion from @mhightower83, move all global objects
into a struct.  This lets a single base pointer register to be used in
place of constantly reloading the address of each individual variable.

This might be better expressed by moving this to a real C++
implementaion based on a class object (the twi.xxxx would go back to the
old xxx-only naming for vars), but there would then need to be API
wrappers since the functionality is exposed through a plain C API.

Saves 168 additional code bytes, for a grand total of 550 bytes IRAM.

earle@server:~/Arduino/hardware/esp8266com/esp8266/tools$ ./xtensa-lx106-elf/bin/xtensa-lx106-elf-objdump -t  -j .text1 /tmp/arduino_build_849115/*elf | sort -k1 | head -20

401000cc l     F .text1	00000014 twi_delay
401000e8  w    F .text1	00000032 twi_releaseBus
40100128 g     F .text1	00000217 twi_onTwipEvent
4010034c l     F .text1	00000149 onSdaChange
4010049c l     F .text1	00000267 onSclChange
40100704 l     F .text1	00000028 onTimer

* Use enums for states, move one more var to twi struct

Make the TWI states enums and not #defines, in the hope that it will
allow GCC to more easily flag problems and general good code
organization.

401000cc l     F .text1	00000014 twi_delay
401000e8  w    F .text1	00000032 twi_releaseBus
40100128 g     F .text1	00000217 twi_onTwipEvent
4010034c l     F .text1	00000149 onSdaChange
4010049c l     F .text1	00000257 onSclChange
401006f4 l     F .text1	00000028 onTimer

Looks like another 16 bytes IRAM saved from the prior push.

Sketch uses 267079 bytes (25%) of program storage space. Maximum is 1044464 bytes.
Global variables use 27696 bytes (33%) of dynamic memory, leaving 54224 bytes for local variables. Maximum is 81920 bytes.

* Save 4 heap bytes by reprdering struct

* Convert to C++ class, clean up code

Convert the entire file into a C++ class (with C wrappers to preserve
the ABI).  This allows for setting individual values of the global
struct(class) in-situ instead of a cryptic list at the end of the struct
definition.  It also removes a lot of redundant `twi.`s from most class
members.

Clean up the code by converting from `#defines` to inline functions, get
rid of ternarys-as-ifs, use real enums, etc.

For slave_receiver.ino, the numbers are:
GIT Master IRAM: 0x723c
This push IRAM: 0x6fc0

For a savings of 636 total IRAM bytes (note, there may be a slight flash
text increase, but we have 1MB of flash to work with and only 32K of IRAM
so the tradeoff makes sense.

* Run astyle core.conf, clean up space/tab/etc.

Since the C++ version has significant text differences anyway, now is a
good time to clean up the mess of spaces, tabs, and differing cuddles.

* Add enum use comment, rename twi::delay, fix SDA/SCL_READ bool usage

Per review comments

* Replace clock stretch repeated code w/inline loop

There were multiple places where the code was waiting for a slave to
finish stretching the clock.  Factor them out to an *inline* function
to reduce code smell.

* Remove slave code when not using slave mode

Add a new twi_setSlaveMode call which actually attached the interrupts
to the slave pin change code onSdaChenge/onSclChange.  Don't attach
interrupts in the main twi_begin.

Because slave mode is only useful should a onoReceive or onRequest
callback, call twi_setSlaveMode and attach interrupts on the Wire
setters.

This allows GCC to not link in slave code unless slave mode is used,
saving over 1,000 bytes of IRAM in the common, master-only case.